### PR TITLE
Use "type": "wp-cli-package" to designate this as a WP-CLI package

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,7 @@
 {
 	"name": "trepmal/wp-revisions-cli",
 	"description": "Manage revisions",
+	"type": "wp-cli-package",
 	"homepage": "https://github.com/trepmal/wp-revisions-cli",
 	"license": "MIT",
 	"require": {


### PR DESCRIPTION
See https://github.com/wp-cli/wp-cli/issues/2567
