### PR TITLE
Create Revision: add `&nbsp;' if there is no one or strip `&nbsp;' otherwise.

### DIFF
--- a/revisions-cli.php
+++ b/revisions-cli.php
@@ -303,7 +303,11 @@ class Revisions_CLI extends WP_CLI_Command {
 			$p = get_post( $post_id );
 			$content = $p->post_content;
 			for ( $i = 0; $i < $count; $i++ ) {
-				$content .= '&nbsp;';
+				if ( substr($content,-6) == '&nbsp;' ) {
+					$content = substr($content, 0, -6);
+				} else {
+					content .= '&nbsp;';
+				}
 				wp_update_post( array(
 					'ID'           => $post_id,
 					'post_content' => $content

--- a/revisions-cli.php
+++ b/revisions-cli.php
@@ -303,10 +303,10 @@ class Revisions_CLI extends WP_CLI_Command {
 			$p = get_post( $post_id );
 			$content = $p->post_content;
 			for ( $i = 0; $i < $count; $i++ ) {
-				if ( substr($content,-6) == '&nbsp;' ) {
-					$content = substr($content, 0, -6);
+				if ( '&nbsp;' === substr( $content, -6 ) ) {
+					$content = substr( $content, 0, -6 );
 				} else {
-					content .= '&nbsp;';
+					$content .= '&nbsp;';
 				}
 				wp_update_post( array(
 					'ID'           => $post_id,


### PR DESCRIPTION
My templates provide some "standard" message and show attached files if there is no content (or `$content == "&nbsp;"` after I've started to use `wp-revisions`). But no one would like to have many `&nbsp;`s in any case :-)

Thank you!