### PR TITLE
List: Add support for defining which fields are included in the output

### DIFF
--- a/revisions-cli.php
+++ b/revisions-cli.php
@@ -81,58 +81,68 @@ class Revisions_CLI extends WP_CLI_Command {
 	public function list_( $args = array(), $assoc_args = array() ) {
 
 		// Default fields to return.
-		$fields = [
+		$fields = WP_CLI\Utils\get_flag_value(
+			$assoc_args,
+			'fields',
+			[
+				'ID',
+				'post_title',
+				'post_parent',
+			]
+		);
+
+		if ( is_string( $fields ) ) {
+			$fields = explode( ',', $fields );
+		}
+
+		// Whitelist the fields we allow to avoid spurious queries.
+		$allowed_fields = [
 			'ID',
+			'post_author',
+			'post_date',
+			'post_date_gmt',
+			'post_content',
 			'post_title',
+			'post_excerpt',
+			'post_status',
+			'comment_status',
+			'ping_status',
+			'post_name',
+			'post_modified',
+			'post_modified_gmt',
+			'post_password',
+			'to_ping',
+			'pinged',
+			'post_content_filtered',
 			'post_parent',
+			'guid',
+			'menu_order',
+			'post_type',
+			'post_mime_type',
+			'comment_count',
 		];
 
-		// Customise the fields that are returned.
-		if ( ! empty( $assoc_args['fields'] ) ) {
+		// Don't allow fields that aren't in the above whitelist.
+		$excluded_fields = array_diff( $fields, $allowed_fields );
 
-			$allowed_fields = [
-				'ID',
-				'post_author',
-				'post_date',
-				'post_date_gmt',
-				'post_content',
-				'post_title',
-				'post_excerpt',
-				'post_status',
-				'comment_status',
-				'ping_status',
-				'post_name'.
-				'post_modified',
-				'post_modified_gmt',
-				'post_password',
-				'to_ping',
-				'pinged',
-				'post_content_filtered',
-				'post_parent',
-				'guid',
-				'menu_order',
-				'post_type',
-				'post_mime_type',
-				'comment_count',
-			];
-
-			// Don't allow fields that aren't in the above whitelist.
-			$excluded_fields = array_diff( $assoc_args['fields'], $allowed_fields );
-			if ( ! empty( $excluded_fields ) ) {
-				WP_CLI::error( 'Invalid values provided in the fields argument.' );
-			}
-
-			$fields = implode( ',', $assoc_args['fields'] );
-
+		if ( ! empty( $excluded_fields ) ) {
+			WP_CLI::error( 'Invalid values provided in the fields argument.' );
 		}
+
+		$fields = array_map(
+			function ( $field ) {
+				return esc_sql( $field );
+			},
+			$fields
+		);
+		$fields = implode( ',', $fields );
 
 		global $wpdb;
 		if ( ! empty( $assoc_args['post_id'] ) ) {
 
 			$revs = $wpdb->get_results(
 				$wpdb->prepare(
-					"SELECT %s FROM $wpdb->posts WHERE post_parent = %d",
-					$fields,
+					"SELECT {$fields} FROM $wpdb->posts WHERE post_parent = %d",
 					$assoc_args['post_id']
 				)
 			);
@@ -154,8 +164,7 @@ class Revisions_CLI extends WP_CLI_Command {
 			// get revisions of those IDs.
 			$revs = $wpdb->get_results(
 				$wpdb->prepare(
-					"SELECT %s FROM $wpdb->posts WHERE post_type = 'revision' AND post_parent IN (%s) ORDER BY post_parent DESC",
-					$fields,
+					"SELECT {$fields} FROM $wpdb->posts WHERE post_type = 'revision' AND post_parent IN (%s) ORDER BY post_parent DESC",
 					$post__in
 				)
 			);
@@ -163,10 +172,7 @@ class Revisions_CLI extends WP_CLI_Command {
 		} else {
 
 			$revs = $wpdb->get_results(
-				$wpdb->prepare(
-					"SELECT %s FROM $wpdb->posts WHERE post_type = 'revision' ORDER BY post_parent DESC",
-					$fields
-				)
+				"SELECT {$fields} FROM $wpdb->posts WHERE post_type = 'revision' ORDER BY post_parent DESC"
 			);
 
 		}

--- a/revisions-cli.php
+++ b/revisions-cli.php
@@ -159,14 +159,18 @@ class Revisions_CLI extends WP_CLI_Command {
 			// get all IDs for posts in given post type(s).
 			$ids = $wpdb->get_col( "SELECT ID FROM $wpdb->posts WHERE 1=2 {$where}" );
 
+			// Prepare the IDs for inclusion in the query.
+			$post__in = array_map(
+				function ( $id ) {
+					return esc_sql( $id );
+				},
+				$ids
+			);
 			$post__in = implode( ',', $ids );
 
 			// get revisions of those IDs.
 			$revs = $wpdb->get_results(
-				$wpdb->prepare(
-					"SELECT {$fields} FROM $wpdb->posts WHERE post_type = 'revision' AND post_parent IN (%s) ORDER BY post_parent DESC",
-					$post__in
-				)
+				"SELECT {$fields} FROM $wpdb->posts WHERE post_type = 'revision' AND post_parent IN ({$post__in}) ORDER BY post_parent DESC"
 			);
 
 		} else {

--- a/revisions-cli.php
+++ b/revisions-cli.php
@@ -32,7 +32,7 @@ class Revisions_CLI extends WP_CLI_Command {
 	public function dump( $args = array(), $assoc_args = array() ) {
 
 		global $wpdb;
-		$revs = $wpdb->get_var( "SELECT COUNT(*) FROM $wpdb->posts WHERE post_type = 'revision'" );
+		$revs = $wpdb->get_var( "SELECT COUNT(*) FROM $wpdb->posts WHERE post_type = 'revision'" ); // phpcs:ignore WordPress.VIP.DirectDatabaseQuery.DirectQuery,WordPress.VIP.DirectDatabaseQuery.NoCaching
 
 		if ( $revs < 1 ) {
 			WP_CLI::success( 'No revisions.' );
@@ -46,7 +46,7 @@ class Revisions_CLI extends WP_CLI_Command {
 			return;
 		}
 
-		$wpdb->query( "DELETE FROM $wpdb->posts WHERE post_type = 'revision'" );
+		$wpdb->query( "DELETE FROM $wpdb->posts WHERE post_type = 'revision'" ); // phpcs:ignore WordPress.VIP.DirectDatabaseQuery.DirectQuery,WordPress.VIP.DirectDatabaseQuery.NoCaching
 
 		WP_CLI::success( 'Finished removing all revisions.' );
 
@@ -140,9 +140,9 @@ class Revisions_CLI extends WP_CLI_Command {
 		global $wpdb;
 		if ( ! empty( $assoc_args['post_id'] ) ) {
 
-			$revs = $wpdb->get_results(
+			$revs = $wpdb->get_results( // phpcs:ignore WordPress.VIP.DirectDatabaseQuery.DirectQuery,WordPress.VIP.DirectDatabaseQuery.NoCaching
 				$wpdb->prepare(
-					"SELECT {$fields} FROM $wpdb->posts WHERE post_parent = %d",
+					"SELECT {$fields} FROM $wpdb->posts WHERE post_parent = %d", //phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared -- $fields is escaped above with esc_sql()
 					$assoc_args['post_id']
 				)
 			);
@@ -157,7 +157,7 @@ class Revisions_CLI extends WP_CLI_Command {
 			}
 
 			// get all IDs for posts in given post type(s).
-			$ids = $wpdb->get_col( "SELECT ID FROM $wpdb->posts WHERE 1=2 {$where}" );
+			$ids = $wpdb->get_col( "SELECT ID FROM $wpdb->posts WHERE 1=2 {$where}" ); // phpcs:ignore WordPress.VIP.DirectDatabaseQuery.DirectQuery,WordPress.VIP.DirectDatabaseQuery.NoCaching,WordPress.DB.PreparedSQL.NotPrepared -- $where is prepared above
 
 			// Prepare the IDs for inclusion in the query.
 			$post__in = array_map(
@@ -169,14 +169,14 @@ class Revisions_CLI extends WP_CLI_Command {
 			$post__in = implode( ',', $ids );
 
 			// get revisions of those IDs.
-			$revs = $wpdb->get_results(
-				"SELECT {$fields} FROM $wpdb->posts WHERE post_type = 'revision' AND post_parent IN ({$post__in}) ORDER BY post_parent DESC"
+			$revs = $wpdb->get_results( // phpcs:ignore WordPress.VIP.DirectDatabaseQuery.DirectQuery,WordPress.VIP.DirectDatabaseQuery.NoCaching
+				"SELECT {$fields} FROM $wpdb->posts WHERE post_type = 'revision' AND post_parent IN ({$post__in}) ORDER BY post_parent DESC" //phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared -- $fields and $post__in are escaped above with esc_sql()
 			);
 
 		} else {
 
-			$revs = $wpdb->get_results(
-				"SELECT {$fields} FROM $wpdb->posts WHERE post_type = 'revision' ORDER BY post_parent DESC"
+			$revs = $wpdb->get_results( // phpcs:ignore WordPress.VIP.DirectDatabaseQuery.DirectQuery,WordPress.VIP.DirectDatabaseQuery.NoCaching
+				"SELECT {$fields} FROM $wpdb->posts WHERE post_type = 'revision' ORDER BY post_parent DESC" //phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared -- $fields is escaped above with esc_sql()
 			);
 
 		}
@@ -283,7 +283,7 @@ class Revisions_CLI extends WP_CLI_Command {
 			}
 
 			// get all IDs for posts in given post type(s).
-			$posts = $wpdb->get_col( "SELECT ID FROM $wpdb->posts WHERE 1=1 {$where}" );
+			$posts = $wpdb->get_col( "SELECT ID FROM $wpdb->posts WHERE 1=1 {$where}" ); // phpcs:ignore WordPress.VIP.DirectDatabaseQuery.DirectQuery,WordPress.VIP.DirectDatabaseQuery.NoCaching,WordPress.DB.PreparedSQL.NotPrepared -- $where is prepared above
 
 		}
 
@@ -338,7 +338,7 @@ class Revisions_CLI extends WP_CLI_Command {
 				} else {
 					$delete_ids = implode( ',', $revisions );
 					if ( empty( $assoc_args['dry-run'] ) ) {
-						$wpdb->query( "DELETE FROM $wpdb->posts WHERE ID IN ($delete_ids)" );
+						$wpdb->query( "DELETE FROM $wpdb->posts WHERE ID IN ($delete_ids)" ); // phpcs:ignore WordPress.VIP.DirectDatabaseQuery.DirectQuery,WordPress.VIP.DirectDatabaseQuery.NoCaching
 					}
 				}
 			}
@@ -400,7 +400,7 @@ class Revisions_CLI extends WP_CLI_Command {
 			}
 
 			// get all IDs for posts in given post type(s).
-			$posts = $wpdb->get_col( "SELECT ID FROM $wpdb->posts WHERE 1=2 {$where}" );
+			$posts = $wpdb->get_col( "SELECT ID FROM $wpdb->posts WHERE 1=2 {$where}" ); // phpcs:ignore WordPress.VIP.DirectDatabaseQuery.DirectQuery,WordPress.VIP.DirectDatabaseQuery.NoCaching,WordPress.DB.PreparedSQL.NotPrepared -- $where is prepared above
 
 		}
 

--- a/revisions-cli.php
+++ b/revisions-cli.php
@@ -114,7 +114,6 @@ class Revisions_CLI extends WP_CLI_Command {
 				'post_type',
 				'post_mime_type',
 				'comment_count',
-				'permalink',
 			];
 
 			// Don't allow fields that aren't in the above whitelist.


### PR DESCRIPTION
Allows users to define a list of DB fields that should be included in the output, defaulting to ID, post_title and post_parent.

P.s. I haven't actually tested this yet :smile: 