### PR TITLE
List: Allow for formats other than table.

### DIFF
--- a/revisions-cli.php
+++ b/revisions-cli.php
@@ -114,7 +114,6 @@ class Revisions_CLI extends WP_CLI_Command {
 		}
 
 		$formatter = new \WP_CLI\Formatter( $assoc_args, array( 'ID', 'post_parent', 'post_title' ), 'revisions' );
-		$formatter->format = ( in_array( $assoc_args['format'], [ 'csv', 'json', 'table' ], true ) ) ? $assoc_args['format'] : 'table';
 		$formatter->display_items( $revs );
 		WP_CLI::success( sprintf( '%d revisions.', $total ) );
 


### PR DESCRIPTION
Allows users to provide the `--format` argument to get csv, json or table output.