### PR TITLE
Fix object cache insanity when `--filter-keep` is enabled

### DIFF
--- a/inc/class-revisions-cli.php
+++ b/inc/class-revisions-cli.php
@@ -320,7 +320,7 @@ class Revisions_CLI extends WP_CLI_Command { // phpcs:ignore WordPressVIPMinimum
 		$total_deleted = 0;
 
 		$this->start_bulk_operation();
-
+		$inc = 0;
 		foreach ( $posts as $post_id ) {
 
 			// phpcs:ignore WordPressVIPMinimum.Functions.RestrictedFunctions.get_posts_get_children
@@ -343,6 +343,10 @@ class Revisions_CLI extends WP_CLI_Command { // phpcs:ignore WordPressVIPMinimum
 
 			if ( isset( $assoc_args['filter-keep'] ) ) {
 				$keep = wp_revisions_to_keep( get_post( $post_id ) );
+				$inc++;
+				if ( $inc % 10 === 0 ) {
+					$this->stop_the_insanity();
+				}
 			}
 
 			$count = count( $revisions );


### PR DESCRIPTION
As soon as `get_post` is used, object cache will start to fill the memory and will crash on large number of posts.

Stop the insanity when `--filter-keep` is enabled